### PR TITLE
Remove wrong character

### DIFF
--- a/ios/Classes/SwiftDialogflowGrpcPlugin.swift
+++ b/ios/Classes/SwiftDialogflowGrpcPlugin.swift
@@ -11,7 +11,7 @@ distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License. */
-s
+
 import Flutter
 import UIKit
 


### PR DESCRIPTION
There is a wrong character in the Swift Dialogflow Grpc Plugin.swift class that prevents the correct compilation of the package for iOS